### PR TITLE
CD/CI updated build-and-test GitHub Action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,10 +3,8 @@ name: build-and-test
 on:
   push:
     branches:
-      - master
   pull_request:
     branches:
-      - master
 
 jobs:
   build:

--- a/src/DevDanApi.Api/Program.cs
+++ b/src/DevDanApi.Api/Program.cs
@@ -1,7 +1,5 @@
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 
 var app = builder.Build();


### PR DESCRIPTION
Project tests should be run after code has been pushed to a branch and before any branches are merged into master